### PR TITLE
Add dark mode and light mode with theme toggle

### DIFF
--- a/components/Card.module.css
+++ b/components/Card.module.css
@@ -1,20 +1,16 @@
 .card {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--glass-bg);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.3),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
   padding: 28px;
   margin: 16px 0;
-  transition: background 0.3s ease, box-shadow 0.3s ease;
+  transition: background 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 .card:hover {
-  background: rgba(255, 255, 255, 0.1);
-  box-shadow:
-    0 12px 40px rgba(0, 0, 0, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  background: var(--glass-bg-hover);
+  box-shadow: var(--glass-shadow-hover);
 }

--- a/components/Footer.module.css
+++ b/components/Footer.module.css
@@ -1,16 +1,17 @@
 .footer {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--glass-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
   padding: 20px;
   margin: 16px 0;
   text-align: center;
+  transition: background 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 .footer p {
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-tertiary);
   font-size: 13px;
 }

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -1,20 +1,18 @@
 .header {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--glass-bg);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.3),
-    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
   padding: 40px 28px;
   margin: 16px 0;
   text-align: center;
-  transition: background 0.3s ease;
+  transition: background 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 .header:hover {
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--glass-bg-hover);
 }
 
 .profilePhoto {
@@ -23,6 +21,7 @@
   border-radius: 50%;
   display: block;
   margin: 16px auto;
-  border: 2px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  border: 2px solid var(--photo-border);
+  box-shadow: var(--photo-shadow);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }

--- a/components/Nav.module.css
+++ b/components/Nav.module.css
@@ -1,31 +1,30 @@
 .nav {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--glass-bg);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.2),
-    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
   padding: 12px 20px;
   margin: 16px 0;
   text-align: center;
   display: flex;
   justify-content: center;
   gap: 8px;
+  transition: background 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 .link {
   padding: 8px 20px;
   font-size: 14px;
   font-variation-settings: 'wght' 500;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--nav-link-color);
   border-radius: 10px;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
 .link:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.95);
+  background: var(--nav-link-hover-bg);
+  color: var(--nav-link-hover-color);
   text-decoration: none;
 }

--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+import styles from './ThemeToggle.module.css';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      setTheme(stored);
+      document.documentElement.setAttribute('data-theme', stored);
+    } else {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      setTheme(prefersDark ? 'dark' : 'light');
+    }
+  }, []);
+
+  function toggleTheme() {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  }
+
+  if (!theme) return null;
+
+  return (
+    <button className={styles.toggle} onClick={toggleTheme} aria-label="Toggle theme">
+      {theme === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19'}
+    </button>
+  );
+}

--- a/components/ThemeToggle.module.css
+++ b/components/ThemeToggle.module.css
@@ -1,0 +1,25 @@
+.toggle {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid var(--glass-border);
+  background: var(--toggle-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  color: var(--toggle-color);
+  font-size: 20px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+  z-index: 100;
+}
+
+.toggle:hover {
+  background: var(--toggle-hover-bg);
+  transform: scale(1.08);
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,7 @@ import Experience from '../components/Experience';
 import Skills from '../components/Skills';
 import Education from '../components/Education';
 import Footer from '../components/Footer';
+import ThemeToggle from '../components/ThemeToggle';
 import styles from './index.module.css';
 
 export default function Home() {
@@ -17,6 +18,7 @@ export default function Home() {
 		<link rel="icon" href="/favicon.ico" />
 	  </Head>
 
+	  <ThemeToggle />
 	  <Header />
 	  <Nav />
 	  <AboutMe />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,6 +14,74 @@
   font-named-instance: 'Italic';
 }
 
+:root {
+  --bg-gradient: linear-gradient(135deg, #e8eaf0 0%, #dde1ea 40%, #d0d5e0 100%);
+  --text-primary: rgba(0, 0, 0, 0.85);
+  --text-secondary: rgba(0, 0, 0, 0.65);
+  --text-tertiary: rgba(0, 0, 0, 0.45);
+  --link-color: #0066cc;
+  --link-hover: #0050a0;
+  --glass-bg: rgba(255, 255, 255, 0.45);
+  --glass-bg-hover: rgba(255, 255, 255, 0.55);
+  --glass-border: rgba(255, 255, 255, 0.6);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  --glass-shadow-hover: 0 12px 40px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  --photo-border: rgba(0, 0, 0, 0.1);
+  --photo-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  --nav-link-color: rgba(0, 0, 0, 0.55);
+  --nav-link-hover-bg: rgba(0, 0, 0, 0.06);
+  --nav-link-hover-color: rgba(0, 0, 0, 0.85);
+  --toggle-bg: rgba(0, 0, 0, 0.06);
+  --toggle-hover-bg: rgba(0, 0, 0, 0.1);
+  --toggle-color: rgba(0, 0, 0, 0.6);
+}
+
+[data-theme="dark"] {
+  --bg-gradient: linear-gradient(135deg, #0f0c29 0%, #302b63 40%, #24243e 100%);
+  --text-primary: rgba(255, 255, 255, 0.9);
+  --text-secondary: rgba(255, 255, 255, 0.75);
+  --text-tertiary: rgba(255, 255, 255, 0.5);
+  --link-color: rgba(120, 180, 255, 0.95);
+  --link-hover: rgba(160, 210, 255, 1);
+  --glass-bg: rgba(255, 255, 255, 0.08);
+  --glass-bg-hover: rgba(255, 255, 255, 0.1);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  --glass-shadow-hover: 0 12px 40px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  --photo-border: rgba(255, 255, 255, 0.2);
+  --photo-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  --nav-link-color: rgba(255, 255, 255, 0.7);
+  --nav-link-hover-bg: rgba(255, 255, 255, 0.1);
+  --nav-link-hover-color: rgba(255, 255, 255, 0.95);
+  --toggle-bg: rgba(255, 255, 255, 0.08);
+  --toggle-hover-bg: rgba(255, 255, 255, 0.15);
+  --toggle-color: rgba(255, 255, 255, 0.7);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-gradient: linear-gradient(135deg, #0f0c29 0%, #302b63 40%, #24243e 100%);
+    --text-primary: rgba(255, 255, 255, 0.9);
+    --text-secondary: rgba(255, 255, 255, 0.75);
+    --text-tertiary: rgba(255, 255, 255, 0.5);
+    --link-color: rgba(120, 180, 255, 0.95);
+    --link-hover: rgba(160, 210, 255, 1);
+    --glass-bg: rgba(255, 255, 255, 0.08);
+    --glass-bg-hover: rgba(255, 255, 255, 0.1);
+    --glass-border: rgba(255, 255, 255, 0.12);
+    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    --glass-shadow-hover: 0 12px 40px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.15);
+    --photo-border: rgba(255, 255, 255, 0.2);
+    --photo-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    --nav-link-color: rgba(255, 255, 255, 0.7);
+    --nav-link-hover-bg: rgba(255, 255, 255, 0.1);
+    --nav-link-hover-color: rgba(255, 255, 255, 0.95);
+    --toggle-bg: rgba(255, 255, 255, 0.08);
+    --toggle-hover-bg: rgba(255, 255, 255, 0.15);
+    --toggle-color: rgba(255, 255, 255, 0.7);
+  }
+}
+
 *,
 *::before,
 *::after {
@@ -31,9 +99,10 @@ body {
   font-variant: common-ligatures contextual;
   letter-spacing: -0.02em;
   min-height: 100vh;
-  background: linear-gradient(135deg, #0f0c29 0%, #302b63 40%, #24243e 100%);
-  color: rgba(255, 255, 255, 0.9);
+  background: var(--bg-gradient);
+  color: var(--text-primary);
   line-height: 1.6;
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
 b, strong, h3, h4, h5, h6 {
@@ -59,13 +128,13 @@ h3 {
 }
 
 a {
-  color: rgba(120, 180, 255, 0.95);
+  color: var(--link-color);
   text-decoration: none;
   transition: color 0.2s ease;
 }
 
 a:hover {
-  color: rgba(160, 210, 255, 1);
+  color: var(--link-hover);
   text-decoration: none;
 }
 
@@ -76,18 +145,18 @@ ul {
 
 li {
   margin-bottom: 8px;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--text-secondary);
   font-size: 14px;
   line-height: 1.5;
 }
 
 p {
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--text-secondary);
   font-size: 15px;
   line-height: 1.6;
 }
 
 span {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-tertiary);
   font-size: 13px;
 }


### PR DESCRIPTION
## Summary
- Add CSS custom properties for all theme-dependent colors (backgrounds, text, glass effects, shadows, borders)
- Light mode: bright glass cards on a soft gray-blue gradient
- Dark mode: existing Liquid Glass aesthetic with deep purple gradient
- Floating toggle button (top-right) to switch between modes
- Respects OS preference via prefers-color-scheme by default
- Persists user choice in localStorage

## Test plan
- [ ] Verify light mode renders with bright glass cards and readable dark text
- [ ] Verify dark mode preserves the existing Liquid Glass look
- [ ] Toggle button switches themes and persists across page reloads
- [ ] With no stored preference, follows OS dark/light setting
- [ ] Smooth transitions when switching themes

Generated with Claude Code